### PR TITLE
Make the wrapper actually transition in Firefox

### DIFF
--- a/public/css/lanyon.css
+++ b/public/css/lanyon.css
@@ -61,6 +61,7 @@ h1, h2, h3, h4, h5, h6 {
  */
 
 .wrap {
+  left: 0;
   position: relative;
   width: 100%;
 }
@@ -238,7 +239,6 @@ a.sidebar-nav-item:focus {
 
 @media (min-width: 30.1rem) {
   .sidebar-toggle {
-    position: fixed;
     width: 2.25rem;
   }
   .sidebar-toggle:before {


### PR DESCRIPTION
Fixes the sidebar toggle rendering over the sidebar in IE

There may be some incidental changes in how the theme renders on small displays with that second change; but the firefox responsive design view indicates it's fine.
