### PR TITLE
Fix Sidebar home highlighting

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -9,7 +9,7 @@
   </div>
 
   <nav class="sidebar-nav">
-    <a class="sidebar-nav-item{% if page.title == "Home" %} active{% endif %}" href="/">Home</a>
+    <a class="sidebar-nav-item{% if page.url == "/" %} active{% endif %}" href="/">Home</a>
 
     {% comment %}
       The code below dynamically generates a sidebar nav of pages with


### PR DESCRIPTION
On root url we don't highlight the home sidebar item. This commit fixes this.
