### PR TITLE
Fix sidebar text and toggle

### DIFF
--- a/public/css/lanyon.css
+++ b/public/css/lanyon.css
@@ -236,19 +236,6 @@ a.sidebar-nav-item:focus {
   background-color: #505050;
 }
 
-@media (min-width: 30.1rem) {
-  .sidebar-toggle {
-    position: fixed;
-    width: 2.25rem;
-  }
-  .sidebar-toggle:before {
-    padding-bottom: .15rem;
-    border-top-width: .45rem;
-    border-bottom-width: .15rem;
-  }
-}
-
-
 /* Slide effect
  *
  * Handle the sliding effects of the sidebar and content in one spot, seperate


### PR DESCRIPTION
There are two styling issues (in my opinion) when the browser width is between 480px and 608px.
1. Sidebar font text is 12px  
   ![screen_shot_2014-01-16_at_6_01_36_pm-2](https://f.cloud.github.com/assets/4662860/1936026/63ff89de-7f02-11e3-8a57-3e179f8241ae.jpg)
2. Sidebar toggle "button" looks uneven  
   ![screen_shot_2014-01-16_at_6_04_22_pm-2](https://f.cloud.github.com/assets/4662860/1936037/a859b488-7f02-11e3-8a5d-3530c168f5b2.jpg)

I'm on Google Chrome Version 31.0.1650.63.

I made some changes which I think fixes the problem. As for deleting the CSS that changes `sidebar-toggle` on some media queries, I wasn't sure what you trying to achieve there but removing it seems for fix the problem! (of course I can be totally wrong)
