### PR TITLE
Fix home link not having a class of active on home page.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,10 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
   <title>
-    {% if page.title %}
-      {{ page.title }} &middot; {{ site.title }}
-    {% else %}
+    {% if page.title == "Home" %}
       {{ site.title }} &middot; {{ site.tagline }}
+    {% else %}
+      {{ page.title }} &middot; {{ site.title }}
     {% endif %}
   </title>
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Home
 ---
 
 <div class="posts">
@@ -34,3 +35,4 @@ layout: default
     <span class="pagination-item newer">Newer</span>
   {% endif %}
 </div>
+


### PR DESCRIPTION
Changes logic in header on how page title gets set. Now checks for the
page title being set to "Home" and sets the format to "site.title •
site.tagline"

All other pages get set to "page.title • site.title"
