### PR TITLE
Use CSS translate instead of absolute positioning on wrapper and sidebar for better performance

### DIFF
--- a/public/css/lanyon.css
+++ b/public/css/lanyon.css
@@ -144,7 +144,10 @@ h1, h2, h3, h4, h5, h6 {
   position: fixed;
   top: 0;
   bottom: 0;
-  left: -14rem;
+  -webkit-transform: translateX(-14rem);
+     -moz-transform: translateX(-14rem);
+      -ms-transform: translateX(-14rem);
+          transform: translateX(-14rem);
   width: 14rem;
   visibility: hidden;
   overflow-y: auto;
@@ -282,18 +285,24 @@ a.sidebar-nav-item:focus {
 }
 .wrap,
 .sidebar-toggle {
-  -webkit-transition: left .3s ease-in-out;
-     -moz-transition: left .3s ease-in-out;
-      -ms-transition: left .3s ease-in-out;
-          transition: left .3s ease-in-out;
+  -webkit-transition: -webkit-transform .3s ease-in-out;
+     -moz-transition: -moz-transform .3s ease-in-out;
+      -ms-transition: -ms-transform .3s ease-in-out;
+          transition: transform .3s ease-in-out;
 }
 
 #sidebar-checkbox:checked + .sidebar {
-  left: 0;
+  -webkit-transform: translateX(0);
+     -moz-transform: translateX(0);
+      -ms-transform: translateX(0);
+          transform: translateX(0);
   visibility: visible;
 }
 #sidebar-checkbox:checked ~ .wrap {
-  left: 14rem;
+  -webkit-transform: translateX(14rem);
+     -moz-transform: translateX(14rem);
+      -ms-transform: translateX(14rem);
+          transform: translateX(14rem);
 }
 
 
@@ -415,16 +424,20 @@ a.pagination-item:hover {
 
 .layout-reverse .wrap,
 .layout-reverse .sidebar-toggle {
-  -webkit-transition-property: right;
-     -moz-transition-property: right;
-      -ms-transition-property: right;
-          transition-property: right;
+  -webkit-transition-property: -webkit-transform;
+     -moz-transition-property: -moz-transform;
+      -ms-transition-property: -ms-transform;
+          transition-property: transform;
 }
 
 
 .layout-reverse .sidebar {
   left: auto;
-  right: -14rem;
+  right: 0;
+  -webkit-transform: translateX(14rem);
+     -moz-transform: translateX(14rem);
+      -ms-transform: translateX(14rem);
+          transform: translateX(14rem);
 }
 .layout-reverse .sidebar-toggle {
   left: auto;
@@ -433,11 +446,17 @@ a.pagination-item:hover {
 
 .layout-reverse #sidebar-checkbox:checked + .sidebar {
   left: auto;
-  right: 0;
+  -webkit-transform: translateX(0);
+     -moz-transform: translateX(0);
+      -ms-transform: translateX(0);
+          transform: translateX(0);
 }
 .layout-reverse #sidebar-checkbox:checked ~ .wrap {
   left: auto;
-  right: 14rem;
+  -webkit-transform: translateX(-14rem);
+     -moz-transform: translateX(-14rem);
+      -ms-transform: translateX(-14rem);
+          transform: translateX(-14rem);
 }
 
 


### PR DESCRIPTION
From Paul Irish's [blog post](http://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/) about using CSS translate on moving elements, I updated positioning of `.wrap` and `.sidebar` from using `left` (and `right`) property to `translateX` and did some quick tests to see if it helps.

toggled sidebar for a couple times.

before: using `left` and `right` positioning
![css-left-right](https://f.cloud.github.com/assets/911894/2030700/c12502be-88f9-11e3-8958-35d66826673f.png)

after: using `translateX`
![css-transform-translate](https://f.cloud.github.com/assets/911894/2030706/e3d69598-88f9-11e3-8ccd-27c80400fde0.png)

as you can see, using `translate` can reduce painting time of toggling sidebar. It also looks "smoother", noticeable on mobile (tested on iPhone 4s, mobile Safari)
