### PR TITLE
pygments is deprecated

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Dependencies
 markdown:         redcarpet
-highlighter:      true
+highlighter:      pygments
 
 # Permalinks
 permalink:        pretty


### PR DESCRIPTION
"Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null."
