### PR TITLE
fix(config): site.baseurl default value is root.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ title:            Lanyon
 tagline:          'A Jekyll theme'
 description:      'A reserved <a href="http://jekyllrb.com" target="_blank">Jekyll</a> theme that places the utmost gravity on content with a hidden drawer. Made by <a href="https://twitter.com/mdo" target="_blank">@mdo</a>.'
 url:              http://lanyon.getpoole.com
+baseurl:          '/'
 paginate:         5
 
 author:


### PR DESCRIPTION
When adding additional pages to the site, the css links can get
messed up until you go back and set a `baseurl` entry in the config.

This makes sense to add this since the project comes with entries for
`baseurl` at the beginning.
