### PR TITLE
feat(tag-clouds): Appear on dedicated posts.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,6 +8,18 @@ layout: default
   {{ content }}
 </div>
 
+{% capture difference %} {{ page.tags | size | minus:1 }} {% endcapture %}
+{% unless difference contains '-' %}
+<div class="tags">
+  <h2>Tags:</h2>
+  <ul>
+    {% for tag in page.tags %}
+      <li class="round tag-cloud">{{ tag }}</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endunless %}
+
 <div class="related">
   <h2>Related Posts</h2>
   <ul class="related-posts">

--- a/public/css/lanyon.css
+++ b/public/css/lanyon.css
@@ -321,6 +321,28 @@ a.sidebar-nav-item:focus {
   color: #9a9a9a;
 }
 
+/* Tags */
+.round {
+  -webkit-border-radius: 12px;
+  -moz-border-radius: 12px;
+  border-radius: 12px;
+}
+
+.tags {
+  padding-top: 2rem;
+  border-top: 1px solid #eee;
+}
+
+.tag-cloud {
+  display: inline-block;
+  padding: 8px;
+  margin-top: 8px;
+  color: #9a9a9a;
+  white-space: pre;
+  background-color: #F8FDFF;
+  border: 2px solid #89CEFF;
+}
+
 /* Related posts */
 .related {
   padding-top: 2rem;


### PR DESCRIPTION
This adds tag clouds (if there are any tags attached to the current post) at
then end of the content posted.

For an example, see http://andrew.yurisich.com/work/2014/06/22/pretty-cat-files-in-terminal/

I'm also filing a bug request against jekyll for not being able to check for emptiness in 
`{% if list == empty %}`. I found a workaround for this issue [on stackoverflow](http://stackoverflow.com/a/16765331/881224).
