### PR TITLE
Ensure site.tagline is available before using it

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
   <title>
-    {% if page.title == "Home" %}
+    {% if page.title == "Home" and site.tagline %}
       {{ site.title }} &middot; {{ site.tagline }}
     {% else %}
       {{ page.title }} &middot; {{ site.title }}


### PR DESCRIPTION
If `site.tagline` isn't set, the `<title>` has nothing after the middot and looks a little silly. This fixes that by checking the tagline is used first.
