### PR TITLE
sort pages in sidebar into logical order (alphabetically by url)

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -16,7 +16,7 @@
       `layout: page` in the front-matter. See readme for usage.
     {% endcomment %}
 
-    {% assign pages_list = site.pages %}
+    {% assign pages_list = site.pages | sort:"url" %}
     {% for node in pages_list %}
       {% if node.title != null %}
         {% if node.layout == "page" %}


### PR DESCRIPTION
Sort pages in sidebar (alphabetic order by url) instead of "random" order.
