### PR TITLE
Fix nil template warning in atom.xml

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
There is a warning when building the source code: 
"Build Warning: Layout 'nil' requested in atom.xml does not exist."
This is because of "layout: nil", to solve this, we need to change to: "layout: null" and it solves the problem. 
