### PR TITLE
Update head.html

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,7 +18,7 @@
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/poole.css">
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/syntax.css">
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/lanyon.css">
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
+  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700%7CPT+Sans:400">
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}public/apple-touch-icon-precomposed.png">


### PR DESCRIPTION
"Bad value http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400 for attribute href on element link: Illegal character in query: not a URL code point." Source: http://validator.w3.org

Solution explained here: http://stackoverflow.com/questions/22466913/google-fonts-url-break-html5-validation-on-w3-org
