### PR TITLE
Add post tags to Lanyon

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ Create tags with `_tools/createTag url-name "Pretty Name"`. Tag posts by adding 
 
 For example:
 
-1. Create a new tag called *using-git*
+* Create a new tag called *using-git*
 
 ```
 $ ./_tools/createTag using-git "Using git"
 ```
 
-2. Create a new post file: `_posts/2014-12-31-how-to-clone-a-repository.md`
+* Create a new post file: `_posts/2014-12-31-how-to-clone-a-repository.md`
 
 ```
 ---
@@ -124,7 +124,7 @@ tags: [using-git, documentation]
 See the [GitHub topic](https://help.github.com/articles/fork-a-repo/). It's pretty good.
 ```
 
-3. Add, commit, and push the updates:
+* Add, commit, and push the updates:
 
 ```
 $ git add _data/tags.yml
@@ -132,6 +132,7 @@ $ git add tag/using-git.md
 $ git add _posts/2014-12-31-how-to-clone-a-repository.md
 $ git commit -m "Add new tag and post"
 $ git push
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Lanyon is an unassuming [Jekyll](http://jekyllrb.com) theme that places content 
   - [Sidebar menu](#sidebar-menu)
   - [Themes](#themes)
   - [Reverse layout](#reverse-layout)
+- [Tags](#tags)
 - [Development](#development)
 - [Author](#author)
 - [License](#license)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,39 @@ It's also available for a reversed layout when you add both classes:
 ```
 
 
+## Tags
+
+Create tags with `_tools/createTag url-name "Pretty Name"`. Tag posts by adding `tags: [tag-name]` to the front matter of post files.
+
+For example:
+
+1. Create a new tag called *using-git*
+
+```
+$ ./_tools/createTag using-git "Using git"
+```
+
+2. Create a new post file: `_posts/2014-12-31-how-to-clone-a-repository.md`
+
+```
+---
+layout: post
+title: How to clone a repository
+tags: [using-git, documentation]
+---
+
+See the [GitHub topic](https://help.github.com/articles/fork-a-repo/). It's pretty good.
+```
+
+3. Add, commit, and push the updates:
+
+```
+$ git add _data/tags.yml
+$ git add tag/using-git.md
+$ git add _posts/2014-12-31-how-to-clone-a-repository.md
+$ git commit -m "Add new tag and post"
+$ git push
+
 ## Development
 
 Lanyon has two branches, but only one is used for active development.

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,0 +1,8 @@
+- slug: jekyll
+  name: Jekyll
+
+- slug: documentation
+  name: Documentation
+
+- slug: examples
+  name: Examples

--- a/_includes/tag_collector.html
+++ b/_includes/tag_collector.html
@@ -5,7 +5,6 @@
 
 {% assign post = page %}
 {% assign tag_list = '' %}
-{% assign tag_separator = ',' %}
 {% assign no_tags_message = 'no tags' %}
 
 {% if post.tags.size > 0 %}
@@ -17,7 +16,7 @@
     {% endfor %}
     {% if tag %}
       {% capture tags_content_temp %}
-        {{ tag_list }}{% include tag_link_formatter.html %}
+        {{ tag_list }}{% include tag_link_formatter.html tag=tag tag_separator=include.tag_separator %}
       {% endcapture %}
       {% assign tag_list = tags_content_temp %}
     {% endif %}

--- a/_includes/tag_collector.html
+++ b/_includes/tag_collector.html
@@ -6,6 +6,7 @@
 {% assign post = page %}
 {% assign tag_list = '' %}
 {% assign tag_separator = ',' %}
+{% assign no_tags_message = 'no tags' %}
 
 {% if post.tags.size > 0 %}
   {% for post_tag in post.tags %}
@@ -22,5 +23,5 @@
     {% endif %}
   {% endfor %}
 {% else %}
-  {% assign tag_list = 'no tags' %}
+  {% assign tag_list = no_tags_message %}
 {% endif %}

--- a/_includes/tag_collector.html
+++ b/_includes/tag_collector.html
@@ -1,0 +1,26 @@
+{% comment %}
+  Fill "tag_list" with a list of links, separated by "tag_separator",
+  using the "tags" front-matter variable for a post.
+{% endcomment %}
+
+{% assign post = page %}
+{% assign tag_list = '' %}
+{% assign tag_separator = ',' %}
+
+{% if post.tags.size > 0 %}
+  {% for post_tag in post.tags %}
+    {% for data_tag in site.data.tags %}
+      {% if data_tag.slug == post_tag %}
+        {% assign tag = data_tag %}
+      {% endif %}
+    {% endfor %}
+    {% if tag %}
+      {% capture tags_content_temp %}
+        {{ tag_list }}{% include tag_link_formatter.html %}
+      {% endcapture %}
+      {% assign tag_list = tags_content_temp %}
+    {% endif %}
+  {% endfor %}
+{% else %}
+  {% assign tag_list = 'no tags' %}
+{% endif %}

--- a/_includes/tag_link_formatter.html
+++ b/_includes/tag_link_formatter.html
@@ -1,0 +1,5 @@
+{% comment %}
+  Format a link to a posts-with-tag page from "tag", a _data/tags.yml object, and "tag_separator".
+{% endcomment %}
+
+<a href="{{ site.baseurl }}tag/{{ tag.slug }}">{{ tag.name }}</a>{% if forloop.last == false %}{{ tag_separator }}{% endif %}

--- a/_includes/tag_link_formatter.html
+++ b/_includes/tag_link_formatter.html
@@ -2,4 +2,4 @@
   Format a link to a posts-with-tag page from "tag", a _data/tags.yml object, and "tag_separator".
 {% endcomment %}
 
-<a href="{{ site.baseurl }}tag/{{ tag.slug }}">{{ tag.name }}</a>{% if forloop.last == false %}{{ tag_separator }}{% endif %}
+<a href="{{ site.baseurl }}tag/{{ include.tag.slug }}">{{ include.tag.name }}</a>{% if forloop.last == false %}{{ include.tag_separator }}{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% include tag_collector.html %}
+{% include tag_collector.html tag_separator=',' %}
 
 <div class="post">
   <h1 class="post-title">{{ page.title }}</h1>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,9 +2,11 @@
 layout: default
 ---
 
+{% include tag_collector.html %}
+
 <div class="post">
   <h1 class="post-title">{{ page.title }}</h1>
-  <span class="post-date">{{ page.date | date_to_string }}</span>
+  <span class="post-date">{{ page.date | date_to_string }} | {{ tag_list }}</span>
   {{ content }}
 </div>
 

--- a/_layouts/posts_by_tag.html
+++ b/_layouts/posts_by_tag.html
@@ -1,0 +1,37 @@
+---
+layout: default
+---
+
+{% for data_tag in site.data.tags %}
+  {% if data_tag.slug == page.tag %}
+    {% assign tag_name = data_tag.name %}
+  {% endif %}
+{% endfor %}
+
+<div class="page">
+  <h1 class="page-title">Posts tagged <em>{{ tag_name }}</em></h1>
+    {% if site.tags[page.tag] %}
+      {% for post in site.tags[page.tag] %}
+        {% capture post_year %}{{ post.date | date: '%Y' }}{% endcapture %}
+        {% if forloop.first %}
+          <h3>{{ post_year }}</h3><div>
+        {% endif %}
+
+        {% if forloop.first == false %}
+          {% assign previous_index = forloop.index0 | minus: 1 %}
+          {% capture previous_post_year %}{{ site.tags[page.tag][previous_index].date | date: '%Y' }}{% endcapture %}
+          {% if post_year != previous_post_year %}
+            </div><h3>{{ post_year }}</h3><div>
+          {% endif %}
+        {% endif %}
+
+        <a href="{{ post.url }}">{{ post.title }}</a><br />
+
+        {% if forloop.last %}
+          </div>
+        {% endif %}
+      {% endfor %}
+    {% else %}
+        <p>There are no posts with this tag.</p>
+    {% endif %}
+</div>

--- a/_layouts/posts_by_tag.html
+++ b/_layouts/posts_by_tag.html
@@ -8,8 +8,11 @@ layout: default
   {% endif %}
 {% endfor %}
 
+{% capture post_tagged_message %}Posts tagged <em>{{ tag_name }}</em>{% endcapture %}
+{% assign no_posts_tagged_message = 'There are no posts with this tag.' %}
+
 <div class="page">
-  <h1 class="page-title">Posts tagged <em>{{ tag_name }}</em></h1>
+  <h1 class="page-title">{{ post_tagged_message }}</h1>
     {% if site.tags[page.tag] %}
       {% for post in site.tags[page.tag] %}
         {% capture post_year %}{{ post.date | date: '%Y' }}{% endcapture %}
@@ -32,6 +35,6 @@ layout: default
         {% endif %}
       {% endfor %}
     {% else %}
-        <p>There are no posts with this tag.</p>
+        <p>{{ no_posts_tagged_message }}</p>
     {% endif %}
 </div>

--- a/_posts/2013-12-31-whats-jekyll.md
+++ b/_posts/2013-12-31-whats-jekyll.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: What's Jekyll?
+tags: [jekyll]
 ---
 
 [Jekyll](http://jekyllrb.com) is a static site generator, an open-source tool for creating simple yet powerful websites of all shapes and sizes. From [the project's readme](https://github.com/mojombo/jekyll/blob/master/README.markdown):

--- a/_posts/2014-01-01-example-content.md
+++ b/_posts/2014-01-01-example-content.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Example content
+tags: [jekyll, documentation, examples]
 ---
 
 

--- a/_posts/2014-01-02-introducing-lanyon.md
+++ b/_posts/2014-01-02-introducing-lanyon.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Introducing Lanyon
+tags: [jekyll, documentation]
 ---
 
 Lanyon is an unassuming [Jekyll](http://jekyllrb.com) theme that places content first by tucking away navigation in a hidden drawer. It's based on [Poole](http://getpoole.com), the Jekyll butler.
@@ -24,6 +25,7 @@ In addition to the features of Poole, Lanyon adds the following:
 * Sidebar includes support for textual modules and a dynamically generated navigation with active link support
 * Two orientations for content and sidebar, default (left sidebar) and [reverse](https://github.com/poole/lanyon#reverse-layout) (right sidebar), available via `<body>` classes
 * [Eight optional color schemes](https://github.com/poole/lanyon#themes), available via `<body>` classes
+* Tags for posts with a tag index page in the sidebar
 
 [Head to the readme](https://github.com/poole/lanyon#readme) to learn more.
 

--- a/_tools/createTag
+++ b/_tools/createTag
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# createTag
+# Copyright 2014 Joe Friedrichsen
+# Licensed under the MIT License
+
+if test $# -ne 2; then
+  echo "Usage: createTag 'slug-name-for-url' 'Pretty Name'"
+  exit 1
+fi
+
+newTagSlugName="$1"
+newTagPrettyName="$2"
+
+gitRepoRoot="$(git rev-parse --show-toplevel)"
+tagDataFile="${gitRepoRoot}/_data/tags.yml"
+tagListFile="${gitRepoRoot}/tag/${newTagSlugName}.md"
+
+if $(echo "${newTagSlugName}" | grep -q "[^a-z0-9_-]"); then
+  echo "Cannot use \"${newTagSlugName}\" for the tag since it contains illegal URL characters. Use lowercase letters, numbers, and '-' or '_'."
+  exit 2
+fi
+
+if $(grep -q "^- slug: ${newTagSlugName}" "${tagDataFile}"); then
+  echo "\"${newTagSlugName}\" is already a tag in \"${tagDataFile}\"."
+  exit 3
+fi 
+
+cat >> "${tagDataFile}" <<-new-tag-entry
+
+	- slug: ${newTagSlugName}
+	  name: ${newTagPrettyName}
+new-tag-entry
+
+cat > "${tagListFile}" <<-new-tag-list-file
+	---
+	layout: posts_by_tag
+	tag: ${newTagSlugName}
+	title: Posts tagged ${newTagPrettyName}
+	---
+
+new-tag-list-file
+
+echo "Created new tag! Use 'git add' on these files:"
+echo "  git add \"${tagDataFile}\" \"${tagListFile}\""
+echo
+echo "Begin using this tag by adding this line to your post's Front Matter:"
+echo "  ---"
+echo "  tags: [${newTagSlugName}]"
+echo "  ---"

--- a/index.html
+++ b/index.html
@@ -12,7 +12,8 @@ title: Home
       </a>
     </h1>
 
-    <span class="post-date">{{ post.date | date_to_string }}</span>
+    {% include tag_collector.html %}
+    <span class="post-date">{{ post.date | date_to_string }} | {{ tag_list }}</span>
 
     {{ post.content }}
   </div>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ title: Home
       </a>
     </h1>
 
-    {% include tag_collector.html %}
+    {% include tag_collector.html tag_separator=',' %}
     <span class="post-date">{{ post.date | date_to_string }} | {{ tag_list }}</span>
 
     {{ post.content }}

--- a/public/css/lanyon.css
+++ b/public/css/lanyon.css
@@ -56,7 +56,7 @@ h1, h2, h3, h4, h5, h6 {
  * Wrapper
  *
  * The wrapper is used to position site content when the sidebar is toggled. We
- * use an outter wrap to position the sidebar without interferring with the
+ * use an outter wrap to position the sidebar without interfering with the
  * regular page content.
  */
 
@@ -253,7 +253,7 @@ a.sidebar-nav-item:focus {
 
 /* Slide effect
  *
- * Handle the sliding effects of the sidebar and content in one spot, seperate
+ * Handle the sliding effects of the sidebar and content in one spot, separate
  * from the default styles.
  *
  * As an a heads up, we don't use `transform: translate3d()` here because when

--- a/tag/documentation.md
+++ b/tag/documentation.md
@@ -1,0 +1,5 @@
+---
+layout: posts_by_tag
+tag: documentation
+title: Posts tagged Documentation
+---

--- a/tag/examples.md
+++ b/tag/examples.md
@@ -1,0 +1,5 @@
+---
+layout: posts_by_tag
+tag: examples
+title: Posts tagged Examples
+---

--- a/tag/jekyll.md
+++ b/tag/jekyll.md
@@ -1,0 +1,5 @@
+---
+layout: posts_by_tag
+tag: jekyll
+title: Posts tagged Jekyll
+---

--- a/tags.md
+++ b/tags.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Tags
+---
+
+{% assign tag_separator = '<br />' %}
+
+<div class="page">
+  {% assign sorted_tags = site.data.tags | sort:"name" %}
+  {% for tag in sorted_tags %}
+    {% include tag_link_formatter.html %}
+  {% endfor %}
+</div>

--- a/tags.md
+++ b/tags.md
@@ -3,11 +3,9 @@ layout: page
 title: Tags
 ---
 
-{% assign tag_separator = '<br />' %}
-
 <div class="page">
   {% assign sorted_tags = site.data.tags | sort:"name" %}
   {% for tag in sorted_tags %}
-    {% include tag_link_formatter.html %}
+    {% include tag_link_formatter.html tag=tag tag_separator='<br />' %}
   {% endfor %}
 </div>


### PR DESCRIPTION
Partial fix for **Issue 83**: [tags or categories on posts?](https://github.com/poole/lanyon/issues/83)

 1. Add `_data/tags.yml` -- storage for tags
 1. Add `tags.md` -- index page for all tags
 1. Add `_includes/tag_collector.html` -- generate tag lists
 1. Add `_includes/tag_link_formatter.html` -- generate tag links
 1. Add `_layouts/posts_by_tag.html` -- page layout for all posts with a given tag
 1. Add `_tools/createTag` -- create a new tag easily and safely
 1. Update `index.html` and `_layouts/post.html` to place the post's tags next to its published date
 1. Update `README.md` and `Introducing Lanyon`

Structure and implementation adapted from @minddust's post: [Categories On GitHub Pages Without Plugins](http://www.minddust.com/post/tags-and-categories-on-github-pages).

**NB**: With the new "Tags" item in the sidebar, the screenshots no longer match. I don't have access to a Mac, so I can't update them :-(