### PR TITLE
Update href links to support user and repo sites

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,5 +6,5 @@ permalink: 404.html
 
 <div class="page">
   <h1 class="page-title">404: Page not found</h1>
-  <p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist. <a href="{{ site.baseurl }}">Head back home</a> to try finding it again.</p>
+  <p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist. <a href="{{ site.baseurl }}/">Head back home</a> to try finding it again.</p>
 </div>

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,12 @@ title:               Lanyon
 tagline:             'A Jekyll theme'
 description:         'A reserved <a href="http://jekyllrb.com" target="_blank">Jekyll</a> theme that places the utmost gravity on content with a hidden drawer. Made by <a href="https://twitter.com/mdo" target="_blank">@mdo</a>.'
 url:                 http://lanyon.getpoole.com
-baseurl:             /
+
+# If this is a user site, keep this one
+baseurl:             
+# If this is a repository site, keep this one
+#baseurl:             /your-repository-name
+
 paginate:            5
 
 # About/contact

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,15 +15,15 @@
   </title>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/poole.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/syntax.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/lanyon.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/poole.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/syntax.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/lanyon.css">
   <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700%7CPT+Sans:400">
 
   <!-- Icons -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}public/apple-touch-icon-precomposed.png">
-  <link rel="shortcut icon" href="{{ site.baseurl }}public/favicon.ico">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/public/apple-touch-icon-precomposed.png">
+  <link rel="shortcut icon" href="{{ site.baseurl }}/public/favicon.ico">
 
   <!-- RSS -->
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ site.baseurl }}/atom.xml">
 </head>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -9,7 +9,7 @@
   </div>
 
   <nav class="sidebar-nav">
-    <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="{{ site.baseurl }}">Home</a>
+    <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="{{ site.baseurl }}/">Home</a>
 
     {% comment %}
       The code below dynamically generates a sidebar nav of pages with
@@ -20,7 +20,7 @@
     {% for node in pages_list %}
       {% if node.title != null %}
         {% if node.layout == "page" %}
-          <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ node.url }}">{{ node.title }}</a>
+          <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ site.baseurl }}{{ node.url }}">{{ node.title }}</a>
         {% endif %}
       {% endif %}
     {% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
       <div class="masthead">
         <div class="container">
           <h3 class="masthead-title">
-            <a href="/" title="Home">{{ site.title }}</a>
+            <a href="{{ site.baseurl }}/" title="Home">{{ site.title }}</a>
             <small>{{ site.tagline }}</small>
           </h3>
         </div>

--- a/atom.xml
+++ b/atom.xml
@@ -6,10 +6,10 @@ layout: null
 <feed xmlns="http://www.w3.org/2005/Atom">
 
  <title>{{ site.title }}</title>
- <link href="{{ site.url }}/atom.xml" rel="self"/>
- <link href="{{ site.url }}/"/>
+ <link href="{{ site.url }}{{ site.baseurl }}/atom.xml" rel="self"/>
+ <link href="{{ site.url }}{{ site.baseurl }}/"/>
  <updated>{{ site.time | date_to_xmlschema }}</updated>
- <id>{{ site.url }}</id>
+ <id>{{ site.url }}{{ site.baseurl }}</id>
  <author>
    <name>{{ site.author.name }}</name>
    <email>{{ site.author.email }}</email>
@@ -18,9 +18,9 @@ layout: null
  {% for post in site.posts %}
  <entry>
    <title>{{ post.title }}</title>
-   <link href="{{ site.url }}{{ post.url }}"/>
+   <link href="{{ site.url }}{{ site.baseurl }}{{ post.url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
-   <id>{{ site.url }}{{ post.id }}</id>
+   <id>{{ site.url }}{{ site.baseurl }}{{ post.id }}</id>
    <content type="html">{{ post.content | xml_escape }}</content>
  </entry>
  {% endfor %}

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ title: Home
   {% for post in paginator.posts %}
   <div class="post">
     <h1 class="post-title">
-      <a href="{{ post.url }}">
+      <a href="{{ site.baseurl }}{{ post.url }}">
         {{ post.title }}
       </a>
     </h1>
@@ -21,15 +21,15 @@ title: Home
 
 <div class="pagination">
   {% if paginator.next_page %}
-    <a class="pagination-item older" href="{{ site.baseurl }}page{{paginator.next_page}}">Older</a>
+    <a class="pagination-item older" href="{{ site.baseurl }}/page{{paginator.next_page}}">Older</a>
   {% else %}
     <span class="pagination-item older">Older</span>
   {% endif %}
   {% if paginator.previous_page %}
     {% if paginator.page == 2 %}
-      <a class="pagination-item newer" href="{{ site.baseurl }}">Newer</a>
+      <a class="pagination-item newer" href="{{ site.baseurl }}/">Newer</a>
     {% else %}
-      <a class="pagination-item newer" href="{{ site.baseurl }}page{{paginator.previous_page}}">Newer</a>
+      <a class="pagination-item newer" href="{{ site.baseurl }}/page{{paginator.previous_page}}">Newer</a>
     {% endif %}
   {% else %}
     <span class="pagination-item newer">Newer</span>


### PR DESCRIPTION
Update href links to support user and repo sites

## Update incomplete links

Some html templates did not use `{{ site.baseurl }}` in their link references. Fix links for repository sites by adding it.

#### Affected files

* atom.xml
* _includes/head.html
* _includes/sidebar.html
* _layouts/default.html
* index.html

## Update link references to match Jekyll convention

Jekyll URL variables (eg `{{ page.url }}`) always *prepend* a slash; however, Lanyon uses `pretty` permalinks, which require a *trailing* slash. Update Lanyon to accommodate *both* **user** and **repository** sites:

### 1) Update `_config.yml` using two rules:

A) `baseurl` must *not* end with a slash to prevent double-slashes appearing in link references on *user* sites.

B) If the site is a *repository* site, `baseurl` *must* begin with a slash to separate the domain name from the base URL as well as allow `{{ site.baseurl }}` to act as the root of a link reference.

### 2) Update the link references in html templates using two rules:

A) If an `href` uses Jekyll variables immediately after `{{ site.baseurl }}`, do *not* place a trailing slash between them.

#### No affected files

B) Otherwise, if an `href` uses any other custom segments after `{{ site.baseurl }}`, *place* a trailing slash after it.

#### Affected files

* 404.html
* _includes/head.html
* _includes/sidebar.html
* index.html

## Testing

### Visual inspection

All inter-site `href` links must begin with a Jekyll variable:

`grep -r href=\" . | grep 'href=\"{{ *site\.b*a*s*e*url *}}'`

Links without a leading Jekyll variable:

`grep -r href=\" . | grep -v href=\"{{`

Hits, all of which are extra-site:

* http://jekyllrb.com
* https://twitter.com/mdo
* http://gmpg.org/xfn/11
* http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700%7CPT+Sans:400
* https://github.com/poole/poole/issues/new
* https://github.com/poole/lanyon

### Interactive

For both classes of site:

1. User -- keep the first empty-string as `baseurl` and serve the site locally
1. Repository -- keep the second `/your-repo-name` as `baseurl` and serve the site locally

Do these interactions:

1. Click:
   * the masthead link
   * a blog title
   * the **Home** page in the sidebar
   * the **About** page in the sidebar
1. Add more posts, reduce pagination to 2, and confirm that *Older* and *Newer* links work on the Home page
1. Use the Browser Console to inspect the `GET` requests for the `head` elements (fonts and css)
