### PR TITLE
Removed slash between site.baseurl and post.url

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ title: Home
   {% for post in paginator.posts %}
   <div class="post">
     <h1 class="post-title">
-      <a href="{{ site.baseurl }}/{{ post.url }}">
+      <a href="{{ site.baseurl }}{{ post.url }}">
         {{ post.title }}
       </a>
     </h1>


### PR DESCRIPTION
I think there shouldn't be a slash between `{{ site.baseurl }}` and `{{ post.url }}`:

![Jekyll URL image](https://byparker.com/img/what-is-a-baseurl.jpg)

If the theme is used on the root path, it will create a url like `//my-post`
