### PR TITLE
Add optional Google Analytics integration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,5 +18,8 @@ author:
   url:               https://twitter.com/mdo
   email:             markdotto@gmail.com
 
+# Optional features
+#google_analytics_id: UA-XXXX-Y
+
 # Custom vars
 version:             1.0.0

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,4 +26,16 @@
 
   <!-- RSS -->
   <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">
+
+  <!-- Google Analytics -->
+  {% if site.google_analytics_id %}
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', '{{ site.google_analytics_id }}', 'auto');
+    ga('send', 'pageview');
+  </script>
+  {% endif %}
 </head>


### PR DESCRIPTION
Rather than users having to copy and modify `_includes/head.html`, now
users need only set the `google_analytics_id` field in `_config.yml`.
