### PR TITLE
Fixed links for subdir hosting

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -20,7 +20,7 @@
     {% for node in pages_list %}
       {% if node.title != null %}
         {% if node.layout == "page" %}
-          <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ node.url }}">{{ node.title }}</a>
+          <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ site.baseurl }}{{ node.url }}">{{ node.title }}</a>
         {% endif %}
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
Page links used to be broken if baseurl is not empty
