### PR TITLE
Add table layout in css

### DIFF
--- a/public/css/poole.css
+++ b/public/css/poole.css
@@ -240,6 +240,7 @@ table {
   width: 100%;
   border: 1px solid #e5e5e5;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 td,
 th {


### PR DESCRIPTION
Without this line a table does not stay within Firefox’s browser window if images are too wide.

Before adding the line:
![screen shot 2015-06-25 at 3 43 46 pm](https://cloud.githubusercontent.com/assets/11637601/8364022/081b749c-1b51-11e5-91f2-799e91c603db.png)

You can't even scroll horizontally.

After adding the line:
![screen shot 2015-06-25 at 3 43 07 pm](https://cloud.githubusercontent.com/assets/11637601/8364025/0b3f1624-1b51-11e5-95ee-28b222f5cc92.png)


For some reason this line is not needed in Safari or Chrome. Haven't tested on other browsers.