### PR TITLE
Fix post link

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ title: Home
   {% for post in paginator.posts %}
   <div class="post">
     <h1 class="post-title">
-      <a href="{{ site.baseurl }}/{{ post.url }}">
+      <a href="{{ post.url | prepend: site.baseurl }}">
         {{ post.title }}
       </a>
     </h1>


### PR DESCRIPTION
The links to the posts were not working : When it should be http://example.org/posts/apost.html it was /posts/apost.html