### PR TITLE
fixed post href path bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ title: Home
   {% for post in paginator.posts %}
   <div class="post">
     <h1 class="post-title">
-      <a href="{{ site.baseurl }}/{{ post.url }}">
+      <a href="{{ site.baseurl }}{{ post.url }}">
         {{ post.title }}
       </a>
     </h1>


### PR DESCRIPTION
Previously, when I intend to click a post title link, it will fail:

![screen shot 2015-07-19 at 11 25 29 pm](https://cloud.githubusercontent.com/assets/8768839/8768147/7bf886aa-2e6d-11e5-9b30-6d935aa6d60f.png)

And I've noticed that in the `index.html` file, all the posts' link href path will be set as `{{ site.baseurl }}/{{ post.url }}`, and this style will not create the relative path as you wish to do.

So I just simply deleted that slash and everything is fine.