### PR TITLE
Fix links to posts on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ title: Home
   {% for post in paginator.posts %}
   <div class="post">
     <h1 class="post-title">
-      <a href="{{ site.baseurl }}/{{ post.url }}">
+      <a href="{{ site.baseurl }}{{ post.url }}">
         {{ post.title }}
       </a>
     </h1>


### PR DESCRIPTION
Explanation how jekyll links work: http://downtothewire.io/2015/08/15/configuring-jekyll-for-user-and-project-github-pages/
