### PR TITLE
Updates Lanyon for Jekyll 3.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 #
 # Use of `relative_permalinks` ensures post links from the index work properly.
 permalink:           pretty
-relative_permalinks: true
+#relative_permalinks: true
 
 # Setup
 title:               Lanyon
@@ -11,6 +11,7 @@ description:         'A reserved <a href="http://jekyllrb.com" target="_blank">J
 url:                 http://lanyon.getpoole.com
 baseurl:             ''
 paginate:            5
+gems: ["jekyll-paginate"]
 
 # About/contact
 author:

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,6 @@ layout: default
 ---
 
 <div class="page">
-  <h1 class="page-title">{{ page.title }}</h1>
-  <a href="{{ site.baseurl }}{{ page.url }}"></a>
-    {{ content }}
+  <h1 class="page-title">{{ page.title }}</h1> 
+  {{ content }}
 </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,5 +4,6 @@ layout: default
 
 <div class="page">
   <h1 class="page-title">{{ page.title }}</h1>
-  {{ content }}
+  <a href="{{ site.baseurl }}{{ page.url }}"></a>
+    {{ content }}
 </div>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ title: Home
   {% for post in paginator.posts %}
   <div class="post">
     <h1 class="post-title">
-      <a href="{{ site.baseurl }}/{{ post.url }}">
+      <a href="{{ site.baseurl }}{{ post.url }}">
         {{ post.title }}
       </a>
     </h1>


### PR DESCRIPTION
Fixes a few concatenation bugs, repairs paginate dependencies, and complies with Jekyll's relative permanent link changes in 3.0
