### PR TITLE
fixed comment tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
-  <!-- Enable responsiveness on mobile devices-->
+  <!-- Enable responsiveness on mobile devices -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
   <title>


### PR DESCRIPTION
if the space before `-->` is not there, it creates problem for other jekyll tools, like jekyll compress by https://github.com/penibelst/jekyll-compress-html. Tools like this depends on specifically `-->` and removes necessary html elements in case a `-->` is  found.
