### PR TITLE
Removing relative permalinks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,6 @@
 #
 # Use of `relative_permalinks` ensures post links from the index work properly.
 permalink:           pretty
-relative_permalinks: true
 
 # Setup
 title:               Lanyon


### PR DESCRIPTION
GitHub Pages and Jekyll no longer support relative permalinks. You must remove the relative_permalinks configuration option from your GitHub Pages site's _config.yml file and reformat any relative permalinks in your site to absolute permalinks.