### PR TITLE
Only show site version and link to GitHub repo if set in `_config.yml`

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -31,7 +31,7 @@
     {% endif %}
     
     {% if site.version != null %}
-    <span class="sidebar-nav-item">Currently v{{ site.version }}</span>
+      <span class="sidebar-nav-item">Currently v{{ site.version }}</span>
     {% endif %}
   </nav>
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -25,9 +25,14 @@
       {% endif %}
     {% endfor %}
 
-    <a class="sidebar-nav-item" href="{{ site.github.repo }}/archive/v{{ site.version }}.zip">Download</a>
-    <a class="sidebar-nav-item" href="{{ site.github.repo }}">GitHub project</a>
+    {% if site.github.repo != null %}
+      <a class="sidebar-nav-item" href="{{ site.github.repo }}/archive/v{{ site.version }}.zip">Download</a>
+      <a class="sidebar-nav-item" href="{{ site.github.repo }}">GitHub project</a>
+    {% endif %}
+    
+    {% if site.version != null %}
     <span class="sidebar-nav-item">Currently v{{ site.version }}</span>
+    {% endif %}
   </nav>
 
   <div class="sidebar-item">


### PR DESCRIPTION
I'm using the beautiful Lanyon theme for a personal blog ([source](https://github.com/sj/sj.github.io), [GitHub pages](https://sj.github.io)). For such setups, I don't think there's much need to link to the GitHub repo or include a version number in the sidebar.

I think this change is useful to others, but feel free to close this PR if you think it's not!