### PR TITLE
Reversed buttons for navigating posts.

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,11 +20,6 @@ title: Home
 </div>
 
 <div class="pagination">
-  {% if paginator.next_page %}
-    <a class="pagination-item older" href="{{ paginator.next_page_path | absolute_url }}">Older</a>
-  {% else %}
-    <span class="pagination-item older">Older</span>
-  {% endif %}
   {% if paginator.previous_page %}
     {% if paginator.page == 2 %}
       <a class="pagination-item newer" href="{{ '/' | absolute_url }}">Newer</a>
@@ -33,5 +28,10 @@ title: Home
     {% endif %}
   {% else %}
     <span class="pagination-item newer">Newer</span>
+  {% endif %}
+  {% if paginator.next_page %}
+    <a class="pagination-item older" href="{{ paginator.next_page_path | absolute_url }}">Older</a>
+  {% else %}
+    <span class="pagination-item older">Older</span>
   {% endif %}
 </div>


### PR DESCRIPTION
Reversing the order of the buttons for navigating posts. Newer post to the left and older posts to the right. Rationale: It's a blog, so posts are in reversed chronological order.

<img width="852" alt="navigation reversed" src="https://user-images.githubusercontent.com/23526123/143957131-83358192-2420-49ca-8bd1-3fe40a085ca0.png">
