### PR TITLE
Change 'site.github.repo' reference to 'site.github.repository_url'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ author:
 # Gems
 plugins:
   - jekyll-paginate
+  - jekyll-github-metadata
 
 # Custom vars
 version:             1.1.0

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -25,8 +25,8 @@
       {% endif %}
     {% endfor %}
 
-    <a class="sidebar-nav-item" href="{{ site.github.repo }}/archive/v{{ site.version }}.zip">Download</a>
-    <a class="sidebar-nav-item" href="{{ site.github.repo }}">GitHub project</a>
+    <a class="sidebar-nav-item" href="{{ site.github.repository_url }}/archive/v{{ site.version }}.zip">Download</a>
+    <a class="sidebar-nav-item" href="{{ site.github.repository_url }}">GitHub Project</a>
     <span class="sidebar-nav-item">Currently v{{ site.version }}</span>
   </nav>
 


### PR DESCRIPTION
According to the latest [GitHub Metadata](https://jekyll.github.io/github-metadata/site.github/) from Jekyll, and what worked for myself. 