### PR TITLE
Fix sidebar z-index

### DIFF
--- a/public/css/lanyon.css
+++ b/public/css/lanyon.css
@@ -142,6 +142,7 @@ h1, h2, h3, h4, h5, h6 {
 /* Style and "hide" the sidebar */
 .sidebar {
   position: fixed;
+  z-index: 10; /* Ensures that the sidebar always stays on top of the main page content */
   top: 0;
   bottom: 0;
   left: -14rem;
@@ -283,7 +284,6 @@ a.sidebar-nav-item:focus {
 }
 
 #sidebar-checkbox:checked + .sidebar {
-  z-index: 10;
   visibility: visible;
 }
 #sidebar-checkbox:checked ~ .sidebar,


### PR DESCRIPTION
Due to the sidebar's z-index only being set to 10 when the sidebar-toggle is active, and unset when inactive, the sidebar appears to be below the other components of the main page content when sliding out of view. I fixed this by applying the z-index property to .sidebar regardless of whether sidebar-toggle is active or not.